### PR TITLE
Always set the NAS identifier; if not set fall back to the hostname

### DIFF
--- a/src/Auth/Source/Radius.php
+++ b/src/Auth/Source/Radius.php
@@ -158,10 +158,7 @@ class Radius extends UserPassBase
 
             $httpUtils = new Utils\HTTP();
             $radius->setNasIpAddress($_SERVER['SERVER_ADDR'] ?: $httpUtils->getSelfHost());
-
-            if ($this->nasIdentifier !== null) {
-                $radius->setAttribute((string)self::RADIUS_NAS_IDENTIFIER, $this->nasIdentifier);
-            }
+            $radius->setAttribute((string)self::RADIUS_NAS_IDENTIFIER, $this->nasIdentifier ?: $httpUtils->getSelfHost());
 
             if ($this->realm !== null) {
                 $radius->setRadiusSuffix('@' . $this->realm);

--- a/src/Auth/Source/Radius.php
+++ b/src/Auth/Source/Radius.php
@@ -157,7 +157,6 @@ class Radius extends UserPassBase
             $radius->setIncludeMessageAuthenticator();
 
             $httpUtils = new Utils\HTTP();
-            $radius->setNasIpAddress($_SERVER['SERVER_ADDR'] ?: $httpUtils->getSelfHost());
             $radius->setAttribute((string)self::RADIUS_NAS_IDENTIFIER, $this->nasIdentifier ?: $httpUtils->getSelfHost());
 
             if ($this->realm !== null) {


### PR DESCRIPTION
Ensure that the NAS identifier is always set to meet standards compliance when no NAS-IP-Address is set